### PR TITLE
feat: surface whether lookup occurred natively in fallback mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,6 @@
 import type * as dns from 'dns';
-declare let osDns: typeof dns & { withNodeFallback: typeof dns };
+declare let osDns: typeof dns & {
+  withNodeFallback: typeof dns,
+  wasNativelyLookedUp: (result: unknown) => boolean;
+};
 export = osDns;

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ const promises = {
   resolveTxt: promisify(resolveTxt),
 };
 
+const kWasNativelyLookedUp = Symbol('os-dns-native.kWasNativelyLookedUp');
+
 function withFallback(fn, nodeFn) {
   return function(...args) {
     const cb = args.pop();
@@ -57,11 +59,16 @@ function withFallback(fn, nodeFn) {
       if (err) {
         nodeFn(...args, cb);
       } else {
+        result[kWasNativelyLookedUp] = true;
         cb(null, result);
       }
     });
   }
 };
+
+function wasNativelyLookedUp(result) {
+  return !!(result && typeof result === 'object' && result[kWasNativelyLookedUp]);
+}
 
 const withNodeFallback = {
   resolve: withFallback(resolve, nodeDns.resolve),
@@ -88,5 +95,6 @@ module.exports = {
   resolveSrv,
   resolveTxt,
   promises,
-  withNodeFallback
+  withNodeFallback,
+  wasNativelyLookedUp
 };


### PR DESCRIPTION
For better diagnostics, surface whether the lookup occurred using
native OS APIs or not.