### PR TITLE
fix: ignore unexpected DNS response types

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -24,7 +24,8 @@ class ResourceRecord {
  public:
   ResourceRecord(ns_msg* msg, size_t initial_pos);
 
-  std::string read(QueryType type) const;
+  QueryType type() const;
+  std::string read() const;
 
   ResourceRecord(ResourceRecord&&) = default;
   ResourceRecord& operator=(ResourceRecord&&) = default;
@@ -195,6 +196,9 @@ std::string ResourceRecord::asSRV() const {
   return name;
 }
 
+QueryType ResourceRecord::type() const {
+  return static_cast<QueryType>(ns_rr_type(record_));
+}
 
 std::pair<const uint8_t*, size_t> ResourceRecord::rawData() const {
   return { ns_rr_rdata(record_), ns_rr_rdlen(record_) };
@@ -274,7 +278,8 @@ class ResourceRecord {
  public:
   ResourceRecord(PDNS_RECORDA record);
 
-  std::string read(QueryType type) const;
+  QueryType type() const;
+  std::string read() const;
 
   ResourceRecord(ResourceRecord&&) = default;
   ResourceRecord& operator=(ResourceRecord&&) = default;
@@ -336,11 +341,6 @@ std::string ResourceRecord::asTXT() const {
 }
 
 std::string ResourceRecord::asA() const {
-  if (record_->wType != DNS_TYPE_A) {
-    throw std::runtime_error("Expected DNS A record, received " +
-        std::to_string(record_->wType));
-  }
-
   uint32_t addr = record_->Data.A.IpAddress;
   std::string rv;
   rv += std::to_string(addr & 0xFF);
@@ -354,11 +354,6 @@ std::string ResourceRecord::asA() const {
 }
 
 std::string ResourceRecord::asAAAA() const {
-  if (record_->wType != DNS_TYPE_AAAA) {
-    throw std::runtime_error("Expected DNS AAAA record, received " +
-        std::to_string(record_->wType));
-  }
-
   const uint8_t* data = reinterpret_cast<const uint8_t*>(&record_->Data.AAAA.Ip6Address);
   char ipv6[60];
   snprintf(ipv6, sizeof(ipv6), "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
@@ -370,18 +365,10 @@ std::string ResourceRecord::asAAAA() const {
 }
 
 std::string ResourceRecord::asCNAME() const {
-  if (record_->wType != DNS_TYPE_CNAME) {
-    throw std::runtime_error("Expected DNS CNAME record, received " +
-        std::to_string(record_->wType));
-  }
   return record_->Data.CNAME.pNameHost;
 }
 
 std::string ResourceRecord::asSRV() const {
-  if (record_->wType != DNS_TYPE_SRV) {
-    throw std::runtime_error("Expected DNS SRV record, received " +
-        std::to_string(record_->wType));
-  }
   const auto& srv = record_->Data.SRV;
 
   std::string name = srv.pNameTarget;
@@ -393,6 +380,10 @@ std::string ResourceRecord::asSRV() const {
   name += std::to_string(srv.wWeight);
 
   return name;
+}
+
+QueryType ResourceRecord::type() const {
+  return static_cast<QueryType>(record_->wType);
 }
 
 DNSResponse::DNSResponse(const std::string& search, PDNS_RECORDA results)
@@ -426,8 +417,8 @@ DNSResponse DNSController::Lookup(
 }
 #endif
 
-std::string ResourceRecord::read(QueryType type) const {
-  switch (type) {
+std::string ResourceRecord::read() const {
+  switch (type()) {
     case QueryType::A:
       return asA();
     case QueryType::AAAA:
@@ -461,7 +452,8 @@ class DNSWorker : public AsyncWorker {
   void OnOK() override;
 
  private:
-  std::vector<std::string> result_;
+  using ResultEntry = std::pair<QueryType, std::string>;
+  std::vector<ResultEntry> result_;
   std::string name_;
   QueryClass cls_;
   QueryType type_;
@@ -471,7 +463,9 @@ void DNSWorker::Execute() {
   DNSController controller;
   DNSResponse response = controller.Lookup(name_, cls_, type_);
   for (const ResourceRecord& record: response.records()) {
-    result_.emplace_back(record.read(type_));
+    result_.emplace_back(ResultEntry {
+      record.type(), record.read()
+    });
   }
 }
 
@@ -479,7 +473,10 @@ void DNSWorker::OnOK() {
   HandleScope scope(Env());
   Array result = Array::New(Env(), result_.size());
   for (size_t i = 0; i < result_.size(); i++) {
-    result[i] = String::New(Env(), result_[i]);
+    Object entry = Object::New(Env());
+    entry["type"] = Number::New(Env(), static_cast<int>(result_[i].first));
+    entry["value"] = String::New(Env(), result_[i].second);
+    result[i] = entry;
   }
   Callback().Call({Env().Null(), result});
 }

--- a/index.js
+++ b/index.js
@@ -3,36 +3,54 @@ const { lookup, constants } = require('bindings')('os_dns_native');
 const { promisify } = require('util');
 const ipv6normalize = require('ipv6-normalize');
 const nodeDns = require('dns');
+const debug = require('debug')('os-dns-native');
+
+const rrtypes = ['A', 'AAAA', 'CNAME', 'TXT', 'SRV'];
+const rrtypeEnumToString = Object.fromEntries(rrtypes.map(t => [constants[t], t]));
 
 function resolve(hostname, rrtype, callback) {
-  switch (rrtype) {
-    case 'A':
-    case 'AAAA':
-    case 'CNAME':
-    case 'TXT':
-    case 'SRV':
-      lookup(hostname, constants.INTERNET, constants[rrtype], function(err, results) {
-        if (err) return callback(err);
-        switch (rrtype) {
-          case 'A':
-          case 'CNAME':
-            return callback(null, results);
-          case 'AAAA':
-            return callback(null, results.map(addr => ipv6normalize(addr)));
-          case 'TXT':
-            return callback(null, results.map(val => val.split('\0')));
-          case 'SRV':
-            return callback(null, results.map(res => {
-              const { name, port, priority, weight } = res.match(
-                /^(?<name>.+):(?<port>\d+),prio=(?<priority>\d+),weight=(?<weight>\d+)$/).groups;
-              return { name, port: +port, priority: +priority, weight: +weight };
-            }));
-        }
-      });
-      return;
-    default:
-      throw new Error(`Unknown rrtype: ${rrtype}`);
+  if (!rrtypes.includes(rrtype)) {
+    throw new Error(`Unknown rrtype: ${rrtype}`);
   }
+
+  lookup(hostname, constants.INTERNET, constants[rrtype], function(err, rawResults) {
+    if (err) {
+      debug(`failed ${rrtype} DNS resolution`, { hostname, err });
+      return callback(err);
+    }
+    debug(`received ${rrtype} DNS resolution`, { hostname, rawResults });
+
+    const results = [];
+    for (const { type, value } of rawResults) {
+      if (type !== constants[rrtype]) {
+        debug(`skipping mismatched DNS answer: wanted ${rrtype} but got ${rrtypeEnumToString[type]}`, { hostname });
+      } else {
+        results.push(value);
+      }
+    }
+
+    if (results.length === 0 && rawResults.length !== 0) {
+      // We encounter this situation when we only saw mismatching results.
+      callback(new Error(`DNS server did not provide matching result for ${rrtype}: ${hostname}`));
+      return;
+    }
+
+    switch (rrtype) {
+      case 'A':
+      case 'CNAME':
+        return callback(null, results);
+      case 'AAAA':
+        return callback(null, results.map(addr => ipv6normalize(addr)));
+      case 'TXT':
+        return callback(null, results.map(val => val.split('\0')));
+      case 'SRV':
+        return callback(null, results.map(res => {
+          const { name, port, priority, weight } = res.match(
+            /^(?<name>.+):(?<port>\d+),prio=(?<priority>\d+),weight=(?<weight>\d+)$/).groups;
+          return { name, port: +port, priority: +priority, weight: +weight };
+        }));
+    }
+  });
 }
 
 function resolve4(hostname, cb) { return resolve(hostname, 'A', cb); }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
+    "debug": "^4.3.3",
     "ipv6-normalize": "^1.0.1",
     "node-addon-api": "^3.1.0"
   },


### PR DESCRIPTION
DNS server responses can mismatch the expected query type.
For example, a DNS server can respond with an A record
even if TXT was requested.

For our purposes, we generally want to ignore these responses.
This is similar to two bugs the MongoDB C driver experienced
in the past. (The code in this package was adapted from the
server code, rather than the C driver code. I think the
server code does not typically encounter these situations
and may also be just fine when they happen.)

Refs: https://jira.mongodb.org/browse/CDRIVER-2789
Refs: https://jira.mongodb.org/browse/CDRIVER-3628