### PR TITLE
chore: Update node-addon-api to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bindings": "^1.5.0",
     "debug": "^4.3.3",
     "ipv6-normalize": "^1.0.1",
-    "node-addon-api": "^3.1.0"
+    "node-addon-api": "^4.3.0"
   },
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
All tests passed for me locally and node-gyp didn't show any errors on build