### PR TITLE
Fix compilation on fedora 39 - aarch64

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -5,6 +5,7 @@
 #include <netinet/in.h>
 #include <arpa/nameser.h>
 #include <resolv.h>
+#include <stdexcept>
 
 namespace {
 


### PR DESCRIPTION
# Issue

Compilation fails on mac m1 pro running asahi linux with the following error:
```
CXX(target) Release/obj.target/os_dns_native/binding.o
../binding.cc: In constructor ‘{anonymous}::ResourceRecord::ResourceRecord(ns_msg*, size_t)’:
../binding.cc:85:16: error: ‘runtime_error’ is not a member of ‘std’
   85 |     throw std::runtime_error(
      |                ^~~~~~~~~~~~~
../binding.cc:8:1: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
    7 | #include <resolv.h>
  +++ |+#include <stdexcept>
    8 | 
```

# Description
This blindly applies the suggested fix which works.