### PR TITLE
chore: Update node-addon-api for Node.js 24 support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,12 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [20.x, 22.x, 24.x]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-26, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [20.x, 22.x, 24.x]
     runs-on: ${{matrix.os}}
     steps:
@@ -19,5 +19,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: npm install
+      - name: Use a faster DNS resolver for failures in Mac.
+        if: runner.os == 'macOS'
+        run: |
+          SERVICE=$(networksetup -listallnetworkservices | tail -n +2 | head -n 1)
+          sudo networksetup -setdnsservers "$SERVICE" 1.1.1.1 1.0.0.1
+          sudo dscacheutil -flushcache
+          sudo killall -HUP mDNSResponder
       - name: Test
         run: npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-26, windows-latest]
         node-version: [20.x, 22.x, 24.x]
     runs-on: ${{matrix.os}}
     steps:

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const rrtypes = ['A', 'AAAA', 'CNAME', 'TXT', 'SRV'];
 const rrtypeEnumToString = Object.fromEntries(rrtypes.map(t => [constants[t], t]));
 
 function providesSrvTypeInResult() {
-    const [major] = process.versions.node.split('.').map(Number)
-    return major >= 24;
+  const [major] = process.versions.node.split('.').map(Number)
+  return major >= 24;
 }
 
 function resolve(hostname, rrtype, callback) {
@@ -50,9 +50,8 @@ function resolve(hostname, rrtype, callback) {
         return callback(null, results.map(val => val.split('\0')));
       case 'SRV':
         return callback(null, results.map(res => {
-          const { name, port, priority, weight } = res.match(
-              /^(?<name>.+):(?<port>\d+),prio=(?<priority>\d+),weight=(?<weight>\d+)$/).groups;
-	  if (providesSrvTypeInResult()) {
+          const { name, port, priority, weight } = res.match(/^(?<name>.+):(?<port>\d+),prio=(?<priority>\d+),weight=(?<weight>\d+)$/).groups;
+          if (providesSrvTypeInResult()) {
             return { name, port: +port, priority: +priority, weight: +weight, type: 'SRV' };
           } else {
             return { name, port: +port, priority: +priority, weight: +weight };

--- a/index.js
+++ b/index.js
@@ -53,10 +53,10 @@ function resolve(hostname, rrtype, callback) {
           const { name, port, priority, weight } = res.match(
               /^(?<name>.+):(?<port>\d+),prio=(?<priority>\d+),weight=(?<weight>\d+)$/).groups;
 	  if (providesSrvTypeInResult()) {
-	    return { name, port: +port, priority: +priority, weight: +weight, type: 'SRV' };
-	  } else {
-	    return { name, port: +port, priority: +priority, weight: +weight };
-	  }
+            return { name, port: +port, priority: +priority, weight: +weight, type: 'SRV' };
+          } else {
+            return { name, port: +port, priority: +priority, weight: +weight };
+          }
         }));
     }
   });

--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ const debug = require('debug')('os-dns-native');
 const rrtypes = ['A', 'AAAA', 'CNAME', 'TXT', 'SRV'];
 const rrtypeEnumToString = Object.fromEntries(rrtypes.map(t => [constants[t], t]));
 
+function providesSrvTypeInResult() {
+    const [major] = process.versions.node.split('.').map(Number)
+    return major >= 24;
+}
+
 function resolve(hostname, rrtype, callback) {
   if (!rrtypes.includes(rrtype)) {
     throw new Error(`Unknown rrtype: ${rrtype}`);
@@ -46,8 +51,12 @@ function resolve(hostname, rrtype, callback) {
       case 'SRV':
         return callback(null, results.map(res => {
           const { name, port, priority, weight } = res.match(
-            /^(?<name>.+):(?<port>\d+),prio=(?<priority>\d+),weight=(?<weight>\d+)$/).groups;
-          return { name, port: +port, priority: +priority, weight: +weight };
+              /^(?<name>.+):(?<port>\d+),prio=(?<priority>\d+),weight=(?<weight>\d+)$/).groups;
+	  if (providesSrvTypeInResult()) {
+	    return { name, port: +port, priority: +priority, weight: +weight, type: 'SRV' };
+	  } else {
+	    return { name, port: +port, priority: +priority, weight: +weight };
+	  }
         }));
     }
   });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bindings": "^1.5.0",
     "debug": "^4.3.3",
     "ipv6-normalize": "^1.0.1",
-    "node-addon-api": "^4.3.0"
+    "node-addon-api": "^8.5.0"
   },
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
The current napi API does not work for Node.js 24 so it has to be updated. The error we get in CI is:

```
[2026/01/09 14:34:01.277]   /usr/local/opt/llvm/bin/clang++ -o Release/obj.target/os_dns_native/binding.o ../binding.cc '-DNODE_GYP_MODULE_NAME=os_dns_native' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DBUILDING_NODE_EXTENSION' -I/Users/ec2-user/Library/Caches/node-gyp/24.12.0/include/node -I/Users/ec2-user/Library/Caches/node-gyp/24.12.0/src -I/Users/ec2-user/Library/Caches/node-gyp/24.12.0/deps/openssl/config -I/Users/ec2-user/Library/Caches/node-gyp/24.12.0/deps/openssl/openssl/include -I/Users/ec2-user/Library/Caches/node-gyp/24.12.0/deps/uv/include -I/Users/ec2-user/Library/Caches/node-gyp/24.12.0/deps/zlib -I/Users/ec2-user/Library/Caches/node-gyp/24.12.0/deps/v8/include -I../../node-addon-api  -O3 -gdwarf-2 -fno-strict-aliasing -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=gnu++20 -stdlib=libc++ -fno-rtti -MMD -MF ./Release/.deps/Release/obj.target/os_dns_native/binding.o.d.raw -I/usr/local/opt/llvm/include  -c
[2026/01/09 14:34:02.141] In file included from ../binding.cc:1:
[2026/01/09 14:34:02.141] ../../node-addon-api/napi.h:1147:39: error: in-class initializer for static data member is not a constant expression
[2026/01/09 14:34:02.141]  1147 |     static const napi_typedarray_type unknown_array_type = static_cast<napi_typedarray_type>(-1);
[2026/01/09 14:34:02.141]       |                                       ^                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026/01/09 14:34:02.141] ../../node-addon-api/napi.h:1147:60: note: integer value -1 is outside the valid range of values [0, 15] for the enumeration type 'napi_typedarray_type'
[2026/01/09 14:34:02.141]  1147 |     static const napi_typedarray_type unknown_array_type = static_cast<napi_typedarray_type>(-1);
[2026/01/09 14:34:02.335]       |                                                            ^
[2026/01/09 14:34:02.335] 1 error generated.
[2026/01/09 14:34:02.341] make: *** [Release/obj.target/os_dns_native/binding.o] Error 1
```

Which is exactly the same as the one we fixed in https://github.com/mongodb-js/mongodb-crypt-library-version/pull/5